### PR TITLE
adding a way to omit protocol

### DIFF
--- a/tasks/security_groups.yml
+++ b/tasks/security_groups.yml
@@ -11,7 +11,7 @@
   os_security_group_rule:
     cloud: "{{ item[0]['cloud'] | default('') }}"
     security_group: "{{ item[0]['name'] }}"
-    protocol: "{{ item[1]['protocol'] | default('tcp') }}"
+    protocol: "{{ item[1]['protocol'] | default('tcp') | regex_replace('^Any$', '') | default(omit, true) }}"
     port_range_min: "{{ item[1]['port_range_min'] | default(omit) }}"
     port_range_max: "{{ item[1]['port_range_max'] | default(item[1]['port_range_min'] | default(omit)) }}"
     remote_ip_prefix: "{{ item[1]['remote_ip_prefix'] }}"


### PR DESCRIPTION
There is currently no way to omit protocol.  Omitting protocol is how you get it to allow any protocol.

This allows that by omitting the protocol key if it is set to "Any".  It's pretty hacky but the only way to maintain backwards compatibility with forcing a default of "tcp" when protocol is left blank, which is how the task works now.

It'd be better to make protocol optional to match the built in module instead of defaulting to tcp but that would break backwards compatibility.