### PR TITLE
security group rules: add support for remote_group

### DIFF
--- a/tasks/security_groups.yml
+++ b/tasks/security_groups.yml
@@ -14,7 +14,8 @@
     protocol: "{{ item[1]['protocol'] | default('tcp') | regex_replace('^Any$', '') | default(omit, true) }}"
     port_range_min: "{{ item[1]['port_range_min'] | default(omit) }}"
     port_range_max: "{{ item[1]['port_range_max'] | default(item[1]['port_range_min'] | default(omit)) }}"
-    remote_ip_prefix: "{{ item[1]['remote_ip_prefix'] }}"
+    remote_ip_prefix: "{{ item[1]['remote_ip_prefix'] | default(omit) }}"
+    remote_group: "{{ item[1]['remote_group'] | default(omit) }}"
     ethertype: "{{ item[1]['ethertype'] | default('IPv4') }}"
   with_subelements:
     - "{{ os_security_groups }}"


### PR DESCRIPTION
Also make remote_group and remote_ip_prefix optional, stop requiring
remote_ip_prefix for all rules.